### PR TITLE
Hide footer bar

### DIFF
--- a/newtab_reloaded/allscripts.js
+++ b/newtab_reloaded/allscripts.js
@@ -11553,6 +11553,9 @@ window.addEventListener("message", function(event) {
     if (options.showAppsPage)
       restoreLastPage();
 
+    if(options.mHideFooter.value)
+      $("footer").style.display = "none";
+
     // Manually call onLoad
     ntp.onLoad();
   }

--- a/newtab_reloaded/background.js
+++ b/newtab_reloaded/background.js
@@ -191,6 +191,7 @@ function getSettings() {
   loadOption(options.mNumberOfTiles);
   loadOption(options.mShowWebstore);
   loadOption(options.mAppsPerRow);
+  loadOption(options.mHideFooter);
   options.showAppsPage = (chrome.management.get != undefined);
   return options;
 }

--- a/newtab_reloaded/config.js
+++ b/newtab_reloaded/config.js
@@ -18,6 +18,11 @@ var options = {
     key: "appsPage.appsPerRow",
     element: "mAppsPerRow",
     defaultValue: 6
+  },
+  mHideFooter: {
+    key: "features.hideFooter",
+    element: "mHideFooter",
+    defaultValue: false
   }
 };
 

--- a/newtab_reloaded/options.htm
+++ b/newtab_reloaded/options.htm
@@ -31,6 +31,15 @@
             </label>
           </div>
         </div>
+
+        <div class="form-group form-group-small">
+          <label class="col-sm-3 control-label"></label>
+          <div class="col-xs-8 checkbox">
+            <label>
+              <input type="checkbox" id="mHideFooter"> Hide footer bar<br>
+            </label>
+          </div>
+        </div>
       </form>
     </div>
 

--- a/newtab_reloaded/options.js
+++ b/newtab_reloaded/options.js
@@ -28,6 +28,7 @@ function loadSettings() {
   setValueFromLocalStorage(options.mNumberOfTiles);
   setValueFromLocalStorage(options.mShowWebstore);
   setValueFromLocalStorage(options.mAppsPerRow);
+  setValueFromLocalStorage(options.mHideFooter);
 }
 
 function applySettings() {
@@ -35,6 +36,7 @@ function applySettings() {
   setLocalStorageFromValue(options.mNumberOfTiles);
   setLocalStorageFromValue(options.mShowWebstore);
   setLocalStorageFromValue(options.mAppsPerRow);
+  setLocalStorageFromValue(options.mHideFooter);
 
   loadSettings();
 }


### PR DESCRIPTION
First, thanks to wjywbs for made this chrome extension.

In order to get the most possible clean newTab I wrote 0 in number of
tiles. But it was not enough, the footer bar should disappear. So I
investigate a bit and I discovered the github project. I started working
in my idea and... I can hide the footer bar now.

So, my fork has a new option to hide the footer.